### PR TITLE
Fix stage preview stutter and render scaling

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -4529,6 +4529,10 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 1515778085106017077, guid: 0a043d66206c6b24db9e571518404be4,
         type: 3}
       insertIndex: -1
+      addedObject: {fileID: 1040566921}
+    - targetCorrespondingSourceObject: {fileID: 1515778085106017077, guid: 0a043d66206c6b24db9e571518404be4,
+        type: 3}
+      insertIndex: -1
       addedObject: {fileID: 1895681073}
     - targetCorrespondingSourceObject: {fileID: 1515778085106017077, guid: 0a043d66206c6b24db9e571518404be4,
         type: 3}
@@ -6387,6 +6391,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _aspectRatioDropdown: {fileID: 795327382}
+  _renderScaleDropdown: {fileID: 749711788}
   _fullScreenButton: {fileID: 1774735188}
   _noteSpeedNumericStepper: {fileID: 989171749}
   _musicVolumeSlider: {fileID: 262328782}
@@ -12646,6 +12651,147 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9d0b96cae44ded640999041914877766, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &749711786
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1040566921}
+    m_Modifications:
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -52
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -22
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4977909958410326523, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 17.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 8663657298750366340, guid: dfb74479b483f7b4c89a67b916bfb19f,
+        type: 3}
+      propertyPath: m_Name
+      value: RenderScaleDropdown
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dfb74479b483f7b4c89a67b916bfb19f, type: 3}
+--- !u!224 &749711787 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3398339747466307869, guid: dfb74479b483f7b4c89a67b916bfb19f,
+    type: 3}
+  m_PrefabInstance: {fileID: 749711786}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &749711788 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2775237137366222146, guid: dfb74479b483f7b4c89a67b916bfb19f,
+    type: 3}
+  m_PrefabInstance: {fileID: 749711786}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64794ae5db8a5ca4a8665f48728cb7bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &759201912
 GameObject:
   m_ObjectHideFlags: 0
@@ -18507,6 +18653,179 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5edf4a797c7347241827744ca91c60c4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1040566920
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 211741940}
+    m_Modifications:
+    - target: {fileID: 1248514660341421392, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_text
+      value: View
+      objectReference: {fileID: 0}
+    - target: {fileID: 1248514660341421392, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 1992097893369130774, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: _localizableText._textOrKey
+      value: NavPanel_View_Label
+      objectReference: {fileID: 0}
+    - target: {fileID: 1992097893369130774, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: _localizableText._isLocalized
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3263179739102235191, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_Name
+      value: RenderScaleProperty
+      objectReference: {fileID: 0}
+    - target: {fileID: 3561328131408740429, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: _text._textOrKey
+      value: NavPanel_View_Label
+      objectReference: {fileID: 0}
+    - target: {fileID: 3561328131408740429, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: _text._isLocalized
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 308
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 154
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -58
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5837958143584374532, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5837958143584374532, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5837958143584374532, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 749711787}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 992e72fc85f146e47ae9af5c0bfbc975, type: 3}
+--- !u!224 &1040566921 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4505387746436102067, guid: 992e72fc85f146e47ae9af5c0bfbc975,
+    type: 3}
+  m_PrefabInstance: {fileID: 1040566920}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1061038412
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -28289,6 +28608,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a67076e91373cfc49adf8f0348e3bf8f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _renderScale: 1
   _aspectRatioFitter: {fileID: 1663545537}
   _viewRawImage: {fileID: 322600282}
   _viewImageAspectRatioFitter: {fileID: 322600281}
@@ -29107,6 +29427,7 @@ GameObject:
   - component: {fileID: 1663545540}
   - component: {fileID: 1663545537}
   - component: {fileID: 1663545543}
+  - component: {fileID: 1663545544}
   m_Layer: 5
   m_Name: PerspectiveViewContent
   m_TagString: Untagged
@@ -29211,6 +29532,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 33f46f2ec0da03143832d040e804aa5e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1663545544
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1663545535}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f9c901dd68dd9b4d846f62ab86f9a91, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  perspectiveViewContent: {fileID: 1663545536}
+  viewRawImage: {fileID: 322600282}
 --- !u!1001 &1684530103
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Runtime/Deenote.UI/Views/PerspectiveViewPanelView.cs
+++ b/Assets/Scripts/Runtime/Deenote.UI/Views/PerspectiveViewPanelView.cs
@@ -16,6 +16,8 @@ namespace Deenote.UI.Views
 {
     public sealed partial class PerspectiveViewPanelView : MonoBehaviour
     {
+        [SerializeField] private float _renderScale = 1.0f;
+
         [SerializeField] AspectRatioFitter _aspectRatioFitter = default!;
         [SerializeField] RawImage _viewRawImage = default!;
         [SerializeField] IntegralSizeAspectRatioFitter _viewImageAspectRatioFitter = default!;
@@ -66,6 +68,51 @@ namespace Deenote.UI.Views
             }
         }
 
+        public event Action<float>? RenderScaleChanged;
+        public float RenderScale
+        {
+            get => _renderScale;
+            set {
+                var scale = Mathf.Clamp(value, 0.5f, 2.0f);
+
+                if (Mathf.Approximately(_renderScale, scale))
+                    return;
+
+                _renderScale = scale;
+
+                if (_viewRenderTexture != null) {
+                    ResizeTargetTexture(default, GetViewSize());
+                }
+
+                RenderScaleChanged?.Invoke(_renderScale);
+            }
+        }
+        private Vector2 GetViewSize()
+        {
+            var rect = _viewRawImage.rectTransform.rect;
+            var canvas = _viewRawImage.canvas;
+            var scaleFactor = canvas != null ? canvas.scaleFactor : 1f;
+
+            return new Vector2(
+                rect.width * scaleFactor * _renderScale,
+                rect.height * scaleFactor * _renderScale);
+        }
+        private void ResizeTargetTexture(Vector2 old, Vector2 size)
+        {
+            var rtSize = new Vector2Int(
+                Mathf.CeilToInt(size.x),
+                Mathf.CeilToInt(size.y));
+
+            if (_viewRenderTexture.width == rtSize.x &&
+                _viewRenderTexture.height == rtSize.y)
+                return;
+
+            _viewRenderTexture.Resize(rtSize);
+
+            MainSystem.GamePlayManager.Stage?
+                .PerspectiveCamera
+                .ApplyToRenderTexture(_viewRenderTexture);
+        }
         private void Awake()
         {
             InitAspectRatioController();
@@ -82,18 +129,6 @@ namespace Deenote.UI.Views
 
                 _viewSize_bf = new FrameCachedNotifyingProperty<Vector2>(GetViewSize, autoUpdate: true);
                 _viewSize_bf.OnValueChanged += ResizeTargetTexture;
-
-                Vector2 GetViewSize()
-                {
-                    var rect = _viewRawImage.rectTransform.rect;
-                    return new Vector2(rect.width, rect.height);
-                }
-
-                void ResizeTargetTexture(Vector2 old, Vector2 size)
-                {
-                    _viewRenderTexture.Resize(MathUtils.RoundToInt(size));
-                    MainSystem.GamePlayManager.Stage?.PerspectiveCamera.ApplyToRenderTexture(_viewRenderTexture);
-                }
             }
         }
 

--- a/Assets/Scripts/Runtime/Deenote.UI/Views/PlayerNavigationPageView.cs
+++ b/Assets/Scripts/Runtime/Deenote.UI/Views/PlayerNavigationPageView.cs
@@ -14,6 +14,7 @@ namespace Deenote.UI.Views
     public sealed class PlayerNavigationPageView : MonoBehaviour
     {
         [SerializeField] Dropdown _aspectRatioDropdown = default!;
+        [SerializeField] Dropdown _renderScaleDropdown = default!;
         [SerializeField] Button _fullScreenButton = default!;
         [SerializeField] NumericStepper _noteSpeedNumericStepper = default!;
         [SerializeField] Slider _musicVolumeSlider = default!;
@@ -43,6 +44,19 @@ namespace Deenote.UI.Views
 
             _fullScreenButton.Clicked += () => MainWindow.Views.PerspectiveViewPanelView.SetIsFullScreen(true);
 
+            _renderScaleDropdown.ResetOptions(_predefinedRenderScaleTexts);
+            _renderScaleDropdown.SelectedIndexChanged += val =>
+            {
+                if (val >= 0)
+                    MainWindow.Views.PerspectiveViewPanelView.RenderScale =
+                        GetRenderScaleDropdownOption(val);
+            };
+
+            MainWindow.Views.PerspectiveViewPanelView.RenderScaleChanged += val =>
+                _renderScaleDropdown.SetValueWithoutNotify(GetRenderScaleDropdownIndex(val));
+
+            _renderScaleDropdown.SetValueWithoutNotify(
+                GetRenderScaleDropdownIndex(MainWindow.Views.PerspectiveViewPanelView.RenderScale));
             #endregion
 
             #region NoteSpeed Volumes Sudden+
@@ -139,5 +153,43 @@ namespace Deenote.UI.Views
                 4f / 3f => 2,
                 _ => -1,
             };
+
+        private static readonly string[] _predefinedRenderScaleTexts =
+        {
+            "0.5x",
+            "0.75x",
+            "1.0x",
+            "1.25x",
+            "1.5x",
+            "2.0x",
+        };
+
+        private static readonly float[] _predefinedRenderScales =
+        {
+            0.5f,
+            0.75f,
+            1.0f,
+            1.25f,
+            1.5f,
+            2.0f,
+        };
+
+        private static float GetRenderScaleDropdownOption(int optionIndex)
+        {
+            if ((uint)optionIndex >= (uint)_predefinedRenderScales.Length)
+                return ThrowHelper.ThrowInvalidOperationException<float>();
+
+            return _predefinedRenderScales[optionIndex];
+        }
+
+        private static int GetRenderScaleDropdownIndex(float option)
+        {
+            for (int i = 0; i < _predefinedRenderScales.Length; i++) {
+                if (Mathf.Approximately(option, _predefinedRenderScales[i]))
+                    return i;
+            }
+
+            return -1;
+        }
     }
 }

--- a/Assets/Scripts/Runtime/Deenote/Core/GamePlay/Audio/GameMusicPlayer.cs
+++ b/Assets/Scripts/Runtime/Deenote/Core/GamePlay/Audio/GameMusicPlayer.cs
@@ -12,7 +12,11 @@ namespace Deenote.Core.GamePlay.Audio
         [SerializeField] AudioSource _source = default!;
 
         private float _time;
+        private double _timeRealtimeAnchor;
+        private float _lastSourceTimeForEvent;
+        private float _lastNotifiedTime;
         private IClipProvider? _factory;
+        private const float DriftHardSyncThreshold = 0.10f;
 
         /// <summary>
         /// The current playback position in seconds.
@@ -22,6 +26,26 @@ namespace Deenote.Core.GamePlay.Audio
         {
             get => _time;
             set => SetTime(value, true);
+        }
+        private float GetSourceTime()
+        {
+            if (_source.clip == null)
+                return _time;
+
+            return Mathf.Clamp(
+                (float)((double)_source.timeSamples / _source.clip.frequency),
+                0f,
+                ClipLength);
+        }
+        private float GetCurrentTime()
+        {
+            if (!IsPlaying || _source.clip == null)
+                return _time;
+
+            var elapsed = UnityEngine.Time.realtimeSinceStartupAsDouble - _timeRealtimeAnchor;
+            var time = _time + (float)elapsed * _source.pitch;
+
+            return Mathf.Clamp(time, 0f, ClipLength);
         }
 
         public float ClipLength
@@ -59,17 +83,31 @@ namespace Deenote.Core.GamePlay.Audio
         /// </summary>
         public event Action<AudioClip>? ClipChanged;
 
+        private void SyncTimeAnchor(float time)
+        {
+            _time = Mathf.Clamp(time, 0f, ClipLength);
+            _timeRealtimeAnchor = UnityEngine.Time.realtimeSinceStartupAsDouble;
+
+            _lastSourceTimeForEvent = _time;
+            _lastNotifiedTime = _time;
+        }
+
         private void SetTime(float value, bool isByJump)
         {
+            value = Mathf.Clamp(value, 0f, ClipLength);
+
             if (Mathf.Approximately(value, _time)) {
-                _time = value;
+                if (isByJump)
+                    _source.time = value;
                 return;
             }
 
             var oldValue = _time;
             _time = value;
+
             if (isByJump)
                 _source.time = value;
+
             TimeChanged?.Invoke(new TimeChangedEventArgs(oldValue, value, isByJump));
         }
 
@@ -80,8 +118,9 @@ namespace Deenote.Core.GamePlay.Audio
         {
             if (IsPlaying)
                 return;
+
+            _source.time = _time;
             _source.Play();
-            _source.time = Time;
         }
 
         /// <summary>
@@ -91,7 +130,19 @@ namespace Deenote.Core.GamePlay.Audio
         {
             if (!IsPlaying)
                 return;
+
+            var oldTime = _time;
+            var sourceTime = GetSourceTime();
+
             _source.Stop();
+            _time = sourceTime;
+
+            if (!Mathf.Approximately(_time, oldTime)) {
+                TimeChanged?.Invoke(new TimeChangedEventArgs(
+                    oldTime,
+                    _time,
+                    false));
+            }
         }
 
         public void TogglePlayingState()
@@ -137,8 +188,31 @@ namespace Deenote.Core.GamePlay.Audio
 
         private void Update()
         {
-            if (IsPlaying) {
-                SetTime(_source.time, isByJump: false);
+            if (!IsPlaying || _source.clip == null)
+                return;
+
+            var oldTime = _time;
+
+            var predictedTime = Mathf.Clamp(
+                _time + UnityEngine.Time.unscaledDeltaTime * _source.pitch,
+                0f,
+                ClipLength);
+
+            var sourceTime = GetSourceTime();
+            var drift = sourceTime - predictedTime;
+
+            if (Mathf.Abs(drift) > DriftHardSyncThreshold) {
+                _time = sourceTime;
+            }
+            else {
+                _time = predictedTime;
+            }
+
+            if (!Mathf.Approximately(_time, oldTime)) {
+                TimeChanged?.Invoke(new TimeChangedEventArgs(
+                    oldTime,
+                    _time,
+                    false));
             }
         }
 

--- a/Assets/Scripts/Runtime/Deenote/Core/GamePlay/GamePlayManager.cs
+++ b/Assets/Scripts/Runtime/Deenote/Core/GamePlay/GamePlayManager.cs
@@ -160,10 +160,15 @@ namespace Deenote.Core.GamePlay
         {
             if (!IsChartLoaded())
                 return;
-            if (!MusicPlayer.IsPlaying && _manualPlaySpeedMultiplier is { } manuallPlaySpeed)
-                MusicPlayer.Nudge(Time.deltaTime * manuallPlaySpeed);
-        }
 
+            if (!MusicPlayer.IsPlaying && _manualPlaySpeedMultiplier is { } manuallPlaySpeed) {
+                MusicPlayer.Nudge(Time.deltaTime * manuallPlaySpeed);
+            }
+
+            if (IsStageLoaded()) {
+                NotesManager.RefreshStageNoteTimeDisplay();
+            }
+        }
         private void OnApplicationFocus(bool focus)
         {
             if (!focus && PauseWhenLoseFocus) {

--- a/Assets/Scripts/Runtime/Deenote/Core/GameStage/NotesManager.cs
+++ b/Assets/Scripts/Runtime/Deenote/Core/GameStage/NotesManager.cs
@@ -467,5 +467,11 @@ namespace Deenote.Core.GameStage
             public int CompareTo(IStageNoteNode other)
                 => Comparer<float>.Default.Compare(_time, _manager._game.GetStageNoteActiveTime(other));
         }
+        internal void RefreshStageNoteTimeDisplay()
+        {
+            foreach (var note in _trackingNotesInTimeOrder) {
+                note.RefreshStageDeltaTime();
+            }
+        }
     }
 }

--- a/Assets/StreamingAssets/Languages/en.txt
+++ b/Assets/StreamingAssets/Languages/en.txt
@@ -53,6 +53,7 @@ NavPanel_ChartRemapVolume_Label=Remap Volume
 Nav_Player=Player
 NavPanel_Player_Header=PLAYER
 NavPanel_View_Label=View
+NavPanel_Scale_Label=Render Scale
 NavPanel_PlayerNoteFallSpeed_Label=Note Speed
 NavPanel_MusicVolume_Label=Music Volume
 NavPanel_EffectVolume_Label=Effect Volume

--- a/Assets/StreamingAssets/Languages/zh.txt
+++ b/Assets/StreamingAssets/Languages/zh.txt
@@ -53,6 +53,7 @@ NavPanel_ChartRemapVolume_Label=重映射音量
 Nav_Player=播放器
 NavPanel_Player_Header=播放器
 NavPanel_View_Label=预览视图
+NavPanel_Scale_Label=渲染倍率
 NavPanel_PlayerNoteFallSpeed_Label=音符下落速度
 NavPanel_MusicVolume_Label=音乐音量
 NavPanel_EffectVolume_Label=音效音量


### PR DESCRIPTION
主要改动：

- 修复播放时谱面音符移动不连续、看起来卡顿的问题。
- 将 `GameMusicPlayer` 的视觉播放时间改为连续推进，不再直接依赖阶梯状更新的 `AudioSource.time / timeSamples`。
- 当播放时间和 `AudioSource` 实际时间偏差过大时，自动校准，避免失焦/切窗口回来后谱面时间大幅跃进。
- 修复高 DPI / Canvas 缩放下 RenderTexture 分辨率偏低的问题。
- 在播放器设置页增加渲染倍率下拉选项。
- 增加渲染倍率设置的中英文文本。