### PR TITLE
facture:拓展对linux平台的兼容性[issue:#41]

### DIFF
--- a/Assets/Scripts/Runtime/Deenote.UI/Dialogs/FileExplorerDialog.cs
+++ b/Assets/Scripts/Runtime/Deenote.UI/Dialogs/FileExplorerDialog.cs
@@ -116,22 +116,10 @@ namespace Deenote.UI.Dialogs
                     _confirmButton.IsInteractable = PathUtils.IsValidFileName(fileName);
             };
 
-#if UNITY_STANDALONE_WIN
             _openInSystemExplorerButton.Clicked += () =>
             {
-                // We locate to the file only if selected file is in current displaying directory
-                if (CurrentSelectedFilePath is not null
-                    && Path.GetDirectoryName(CurrentSelectedFilePath.AsSpan()).SequenceEqual(CurrentDirectory)) {
-                    //                                                             Ensure path seperator charater is valid
-                    System.Diagnostics.Process.Start("explorer.exe", $@"/select,""{Path.GetFullPath(CurrentSelectedFilePath)}""");
-                }
-                else {
-                    System.Diagnostics.Process.Start("explorer.exe", Path.GetFullPath(CurrentDirectory));
-                }
+                OpenInSystemFileManager();
             };
-#else
-            _openInSystemExplorerButton.gameObject.SetActive(false);
-#endif
         }
 
         private void OnDisable()
@@ -307,6 +295,39 @@ namespace Deenote.UI.Dialogs
 
             public static InputBar WithDefaultText(string? input, string? extension)
                 => new(InputBarKind.Input, input, extension);
+        }
+
+        private void OpenInSystemFileManager()
+        {
+#if UNITY_STANDALONE_WIN
+            // Windows: explorer.exe with /select flag to highlight the file
+            if (CurrentSelectedFilePath is not null
+                && Path.GetDirectoryName(CurrentSelectedFilePath.AsSpan()).SequenceEqual(CurrentDirectory)) {
+                System.Diagnostics.Process.Start("explorer.exe",
+                    string.Format("/select,\"{0}\"", Path.GetFullPath(CurrentSelectedFilePath)));
+            }
+            else {
+                System.Diagnostics.Process.Start("explorer.exe", Path.GetFullPath(CurrentDirectory));
+            }
+#elif UNITY_STANDALONE_OSX
+            // macOS: use 'open' command with -R flag to reveal in Finder
+            if (CurrentSelectedFilePath is not null
+                && Path.GetDirectoryName(CurrentSelectedFilePath.AsSpan()).SequenceEqual(CurrentDirectory)) {
+                System.Diagnostics.Process.Start("open",
+                    string.Format("-R \"{0}\"", Path.GetFullPath(CurrentSelectedFilePath)));
+            }
+            else {
+                System.Diagnostics.Process.Start("open", Path.GetFullPath(CurrentDirectory));
+            }
+#else
+            // Linux: use xdg-open (freedesktop.org standard)
+            // xdg-open does not support file-selection flags; open the parent directory
+            var target = CurrentSelectedFilePath is not null
+                && Path.GetDirectoryName(CurrentSelectedFilePath.AsSpan()).SequenceEqual(CurrentDirectory)
+                ? Path.GetDirectoryName(CurrentSelectedFilePath)
+                : CurrentDirectory;
+            System.Diagnostics.Process.Start("xdg-open", Path.GetFullPath(target));
+#endif
         }
     }
 }

--- a/Assets/Scripts/Runtime/Deenote/Core/Project/ProjectManager.cs
+++ b/Assets/Scripts/Runtime/Deenote/Core/Project/ProjectManager.cs
@@ -10,7 +10,6 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
-using System.Drawing;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Assets/Scripts/Runtime/Library/AudioUtils.cs
+++ b/Assets/Scripts/Runtime/Library/AudioUtils.cs
@@ -2,6 +2,7 @@
 
 using Cysharp.Threading.Tasks;
 using NAudio.Wave;
+using NLayer.NAudioSupport;
 using System;
 using System.Buffers;
 using System.IO;
@@ -38,7 +39,8 @@ namespace Deenote.Library
                         break;
                     case ".mp3" or ".MP3":
                         var id3TagLength = SkipID3Tag(stream);
-                        wave = new Mp3FileReader(stream);
+                        var builder = new Mp3FileReaderBase.FrameDecompressorBuilder(wf => new Mp3FrameDecompressor(wf));
+                        wave = new Mp3FileReaderBase(stream, builder);
                         Mp3Frame frame = Mp3Frame.LoadFromStream(stream);
                         initialSampleCount = frame.SampleCount * wave.WaveFormat.Channels;
                         stream.Seek(id3TagLength, SeekOrigin.Begin);
@@ -55,7 +57,7 @@ namespace Deenote.Library
                 try {
                     try {
                         provider.Read(raw, 0, (int)length);
-                    } catch (NAudio.MmException) {
+                    } catch (Exception ex) when (ex is NAudio.MmException or InvalidDataException or IOException or EndOfStreamException) {
                         return null;
                     }
 

--- a/Assets/Scripts/Runtime/UIFramework/Font/UIFontManager.cs
+++ b/Assets/Scripts/Runtime/UIFramework/Font/UIFontManager.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using TMPro;
+using UnityEngine;
 
 namespace Deenote.UIFramework.Font
 {
@@ -19,6 +20,12 @@ namespace Deenote.UIFramework.Font
 
             _systemFontPaths ??= UnityEngine.Font.GetPathsToOSFonts();
             var fontPath = Array.Find(_systemFontPaths, path => Path.GetFileNameWithoutExtension(path) == name);
+            if (fontPath is null) {
+                Debug.LogWarning($"Font '{name}' not found on this system, falling back to first available font");
+                fontPath = _systemFontPaths.Length > 0 ? _systemFontPaths[0] : null;
+                if (fontPath is null)
+                    throw new InvalidOperationException("No system fonts available");
+            }
             asset = TMP_FontAsset.CreateFontAsset(new UnityEngine.Font(fontPath));
             asset.atlasPopulationMode = TMPro.AtlasPopulationMode.Dynamic;
             (_cacheFontAssets ??= new()).Add(name, asset);

--- a/Assets/Scripts/StartupController.cs
+++ b/Assets/Scripts/StartupController.cs
@@ -41,7 +41,7 @@ namespace Deenote
 
 #if UNITY_EDITOR
             Debug.Log("Ignored command line args in editor mode");
-#elif UNITY_STANDALONE_WIN
+#else
             if (GetCommandLineArg0() is { } clfile) {
                 _ = OpenProjectFromCommandLineAsync(clfile);
             }

--- a/Assets/Shaders/PerspectiveLinesShader.shader
+++ b/Assets/Shaders/PerspectiveLinesShader.shader
@@ -115,7 +115,9 @@
 					float2 dir = (i.ndcLine.zw - i.ndcLine.xy) * aspectRatio;
 					dir = normalize(float2(-dir.y, dir.x));
 					float2 ndc = (i.vertex.xy / _ScreenParams.xy) * 2 - 1;
+					#if UNITY_UV_STARTS_AT_TOP
 					ndc.y = -ndc.y;
+					#endif
 					const float2 frag2p0 = (i.ndcLine.zw - ndc) * aspect;
 					const float2 dist = abs(dot(frag2p0, dir));
 					alpha *= clamp((i.width / 2 - dist) / _SmoothingPx + 0.5, 0, 1);

--- a/Assets/packages.config
+++ b/Assets/packages.config
@@ -2,19 +2,14 @@
 <packages>
   <package id="CommunityToolkit.Diagnostics" version="8.4.0" manuallyInstalled="true" />
   <package id="CommunityToolkit.HighPerformance" version="8.4.0" manuallyInstalled="true" />
-  <package id="Microsoft.Win32.Registry" version="4.7.0" />
-  <package id="NAudio" version="2.2.1" manuallyInstalled="true" />
   <package id="NAudio.Asio" version="2.2.1" />
   <package id="NAudio.Core" version="2.2.1" />
   <package id="NAudio.Midi" version="2.2.1" />
-  <package id="NAudio.Wasapi" version="2.2.1" />
-  <package id="NAudio.WinForms" version="2.2.1" />
-  <package id="NAudio.WinMM" version="2.2.1" />
   <package id="Newtonsoft.Json" version="13.0.3" manuallyInstalled="true" />
   <package id="Octokit" version="13.0.1" manuallyInstalled="true" />
   <package id="Semver" version="2.3.0" manuallyInstalled="true" />
   <package id="System.Collections.Immutable" version="9.0.0" manuallyInstalled="true" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" manuallyInstalled="true" />
-  <package id="System.Security.AccessControl" version="4.7.0" />
-  <package id="System.Security.Principal.Windows" version="4.7.0" />
+  <package id="NLayer" version="2.0.1" manuallyInstalled="true" />
+  <package id="NLayer.NAudioSupport" version="2.0.1" manuallyInstalled="true" />
 </packages>


### PR DESCRIPTION
对于issue #41的具体实现：
1. 修复在对dx的坐标的修正导致的opengl下不具合的问题
2. 替换mp3音频解码的实现方案为nplayer使其在linux下正常工作
3. 修改在文件管理器中打开的方式，使其在windows下保持不变，在linux下使用xdg-open
4. 修改只在windows下处理命令行传入的打开文件的问题
5. 修改因为硬编码的字体找不到导致报错的问题（不是很彻底，毕竟最好的是有套回退系统或者能够在配置里面更改）
6. 更改了一点依赖